### PR TITLE
Publish 2.2.0b1 under whylabs-datasketches name

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,0 +1,64 @@
+name: Build Wheels
+
+on: [ push, pull_request ]
+
+jobs:
+  build_wheels:
+    name: Build Wheels On ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      matrix:
+        config:
+          - {
+            name: "MacOS Latest, Clang",
+            os: macos-latest,
+            test_target: test,
+            cc: "clang", cxx: "clang++"
+          }
+          - {
+            name: "Ubuntu Latest, GCC",
+            os: ubuntu-latest,
+            test_target: test,
+            cc: "gcc", cxx: "g++"
+          }
+#          - {
+#            name: "Windows Latest, MSVC",
+#            os:  v,
+#            test_target: RUN_TESTS,
+#            cc: "cl", cxx: "cl",
+#            environment_script: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Auxiliary/Build/vcvars64.bat"
+#          }
+            #- {
+            #    name: "Windows Latest, MinGW+gcc",
+          #    os: windows-latest,
+          #    cc: "gcc", cxx: "g++"
+          #  }
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install cibuildwheel
+        run: |
+          pip install wheel
+          pip install -e ".[compat,dev]" cibuildwheel twine
+      - name: Install Python dependencies
+        run: python -m pip install --upgrade pip setuptools wheel numpy tox
+      - name: Configure
+        run: |
+
+          python setup.py bdist_wheel
+          cibuildwheel --output-dir dist
+          ls dist
+        env:
+          CIBW_BUILD: "cp36-* cp37-* cp38-* cp39-*"
+          CIBW_BEFORE_BUILD: "rm -fr python/datasketches.* && rm -fr build/* && pip install cython"
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/*.whl

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ Default/
 .eggs/
 .tox/
 dist/
-python/datasketches.egg-info/
+python/whylabs_datasketches.egg-info/
 
 # Log file
 
@@ -40,3 +40,8 @@ _*/
 
 # exceptions
 !__init__.py
+
+.idea
+
+cmake-build-debug
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/pypa/manylinux2010_x86_64
+
+RUN yum update
+
+RUN mkdir /io
+WORKDIR /io
+
+COPY . .
+
+RUN ls python/ -alh
+RUN ./build_wheels.sh

--- a/build_wheels.sh
+++ b/build_wheels.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e -u -x
+
+PLAT=manylinux2010_x86_64
+
+function repair_wheel {
+    wheel="$1"
+    if ! auditwheel show "$wheel"; then
+        echo "Skipping non-platform wheel $wheel"
+    else
+        auditwheel repair "$wheel" --plat "$PLAT" -w dist/
+    fi
+}
+
+# Compile wheels
+for PYBIN in /opt/python/*/bin; do
+    "${PYBIN}/pip" install wheel
+    "${PYBIN}/pip" wheel . --no-deps -w dist/
+done
+
+# Bundle external shared libraries into the wheels
+for whl in dist/*.whl; do
+    repair_wheel "$whl"
+done

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ class CMakeBuild(build_ext):
         cmake_args += ['-DWITH_PYTHON=True']
         cfg = 'Debug' if self.debug else 'Release'
         build_args = ['--config', cfg]
+        # Require to enable Pybind11 to pick up the correct Python paths
+        cmake_args += ['-DPYTHON_EXECUTABLE=' + sys.executable]
 
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(
@@ -76,8 +78,8 @@ class CMakeBuild(build_ext):
         print() # add an empty line to pretty print
 
 setup(
-    name='datasketches',
-    version='2.2.0-SNAPSHOT',
+    name='whylabs-datasketches',
+    version='2.2.0b1',
     author='Datasketches Developers',
     author_email='dev@datasketches.apache.org',
     description='A wrapper for the C++ Datasketches library',


### PR DESCRIPTION
Mostly FYI since I already published the new version to Pypi.

* Enable CMake to pick up the correct Python headers
* Add manylinux docker build logic (needs to manually copy artifacts out atm)
* For MacOSX, I manually built and published artifacts 

```
conda activate datasketches-3.[5,6,7,8,9]
pip wheel . --no-deps -w dist/
```